### PR TITLE
Mengosongkan folder public hanya jika tahap build

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,10 @@ let codeTagHolder = []
 
 //Pages file
 const pages = fs.readdirSync(dir.pages)
-fs.emptyDirSync(dir.public)
+// fs.emptyDirSync(dir.public)
+if (!process.argv.includes('--watch')) {
+	fs.emptyDirSync(dir.public)
+}
 createFolderIfNone(dir.public)
 pages.forEach(function(page) {
 	generateFile(`${dir.pages}/${page}`, page)


### PR DESCRIPTION
Untuk kecepatan proses development, file-file dan folder-folder yang ada di folder public, hanya akan dikosongkan kemudian diisi ulang, hanya saat build. Ketika dev, jangan dihapus isinya. Hal ini akan lebih cepat daripada dikosongkan dulu. Sebagaimana yang dilakukan oleh Windi CSS: <https://windicss.org/integrations/cli.html#dev-mode>

> Note: For better hotloading experience (~5ms) we don't remove built css at development time, so you are expected to rebuild it once at release time using the minimize command to get the best experience for both development and build. Such as windicss './**/*.html' -mto windi.css